### PR TITLE
PDF Summary Improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@aws-sdk/client-s3": "^3.325.0",
                 "@aws-sdk/client-sqs": "^3.332.0",
                 "@aws-sdk/util-stream-node": "^3.350.0",
-                "@shipper/pdfkit-html-simple": "^1.0.3",
+                "@shipper/pdfkit-html-simple": "github:InformedSolutions/pdfkit-html-simple#v1.0.4",
                 "@slack/webhook": "^6.0.0",
                 "ajv": "^6.12.6",
                 "ajv-errors": "^1.0.1",
@@ -4854,9 +4854,9 @@
             }
         },
         "node_modules/@shipper/pdfkit-html-simple": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@shipper/pdfkit-html-simple/-/pdfkit-html-simple-1.0.3.tgz",
-            "integrity": "sha512-ksJQvLxv+1XpH0V/E5/ufpJKdyVEm0WAatpZKzxU4m+r0uaNILm5nwkbHSGX3IuFDb3QfhTKJJa4y3OfL7Kq1Q==",
+            "version": "1.0.4",
+            "resolved": "git+ssh://git@github.com/InformedSolutions/pdfkit-html-simple.git#83ec663c3a0ba79d7a8f95efd60b1253b75b0272",
+            "license": "Apache-2.0",
             "dependencies": {
                 "cheerio": "^0.22.0",
                 "css": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "@aws-sdk/client-s3": "^3.325.0",
         "@aws-sdk/client-sqs": "^3.332.0",
         "@aws-sdk/util-stream-node": "^3.350.0",
-        "@shipper/pdfkit-html-simple": "^1.0.3",
+        "@shipper/pdfkit-html-simple": "github:InformedSolutions/pdfkit-html-simple#v1.0.4",
         "@slack/webhook": "^6.0.0",
         "ajv": "^6.12.6",
         "ajv-errors": "^1.0.1",

--- a/services/pdf/index.js
+++ b/services/pdf/index.js
@@ -158,6 +158,9 @@ function createPdfService() {
                 const yPos = pdfDocument.y;
                 const lineHeight = pdfDocument.currentLineHeight();
 
+                // If we are too close to the bottom of the page, start writing the header
+                // to the top of a new page instead. This is calculated based on the current Y position
+                // in relation to the bottom border of the page, with a buffer of (25 + line height)
                 if (yPos > bottomBorder - bottomMargin - lineHeight - 25) {
                     pdfDocument.addPage();
                 }

--- a/services/pdf/index.js
+++ b/services/pdf/index.js
@@ -126,7 +126,7 @@ function createPdfService() {
                 const {bottom} = document.page.margins;
                 document.page.margins.bottom = 0;
 
-                const date = moment(json.meta.submittedDate).format('DD/MM/YYYY hh:mm A');
+                const date = moment().format('DD/MM/YYYY hh:mm A');
                 document
                     .fontSize(10)
                     .font('Helvetica')
@@ -153,6 +153,15 @@ function createPdfService() {
             // Loops over each theme in the json, and for each writes the header and then
             //     loops through each question in the theme, which are each written using addPDFQuestion
             Object.keys(json.themes).forEach(function(t) {
+                const bottomMargin = pdfDocument.page.margins.bottom;
+                const bottomBorder = pdfDocument.page.height;
+                const yPos = pdfDocument.y;
+                const lineHeight = pdfDocument.currentLineHeight();
+
+                if (yPos > bottomBorder - bottomMargin - lineHeight - 25) {
+                    pdfDocument.addPage();
+                }
+
                 const theme = json.themes[t];
                 pdfDocument.fontSize(14.5).font('Helvetica-Bold');
 
@@ -184,7 +193,15 @@ function createPdfService() {
             pdfDocument.fillColor('#444444');
 
             // Get the HTML string from the declaration section of the application json.
-            const bufStr = json.declaration.label;
+            let bufStr = json.declaration.label;
+            bufStr = `
+                <style>p { margin: 10px;}</style>
+                ${bufStr}
+                <p style="font-weight: bold;">Date: ${moment(json.meta.submittedDate).format(
+                    'DD/MM/YYYY'
+                )}</p>
+                <p style="font-weight: bold;">I have read and understood the information and declaration</p>
+                `;
             const htmlBuffer = Buffer.from(bufStr, 'utf8');
 
             PDFKitHTML.parse(htmlBuffer)


### PR DESCRIPTION
- Switched to a fork of the node library used to integrate pdfkit and HTML, this fork supports lists and links amongst other things
- Switch the date in the footer to be the document generation date as opposed to the applicant submitted date (which is added to the declaration signature - this aligns with current prod
- If we get too close to the end of the page when writing a section header, start it on the next page instead