### PR TITLE
Update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+NODE_ENV='local'
+APPLICATION_QUEUE_ID='http://localhost:4566/000000000000/application-queue'
+TEMPUS_QUEUE_ID='http://localhost:4566/000000000000/tempus-queue'
+S3_BUCKET='application-bucket'

--- a/README.md
+++ b/README.md
@@ -1,17 +1,69 @@
-# Application Service
+# Application service (Node.js)
+This application is set up to run as a container in a Kubernetes environment with the end goals being to:
+- Generate an Application Summary Form (PDF format) and insert this into S3
+- Forward on the SQS message to the Tempus Broker (via Tempus Queue) containing a reference to the S3 location that the application summary was uploaded to.
 
-## Getting started
+Key process steps:
 
-1. Down repo
-2. run `npm install`
-3. run `npm run start:dev`
-4. View api docs at: `http://localhost:3800/docs/`
+- The function is triggered by an SQS event which contains an S3 key for an application PDF and its corresponding JSON data.
+- The function will retrieve the JSON from an S3 bucket generate a PDF dynamically using a library called PDFKit
+- This generated PDF will be uploaded to S3
+- A new SQS message is generated containing the original data, with the new upload location added as a separate key
 
-### Notes
+The project source includes the following directories:
 
-* Listening port can be found in `bin/www` currently `3800`
-* There is a secret and a JWT in `foo/foo-routes.js` for demo purposes. The JWT can be used in the OpenAPI (swagger) docs to try out the endpoints. These SHOULD NOT live in the codedase.
-* Start API with `npm run start:dev`. This will watch for file changes and reload the api. Also allows for a debugger to be attached. Standard `npm run start` is also available.
-* Once running, view docs and try `foo` endpoints at `http://localhost:3800/docs/`
-* Any `process.env` vars will need to be handled correctly e.g. as part a Docker compose file.
-* OpenAPI src files can be found in `openapi/src`. This will auto build on `npm install`, running tests, and modifying the openapi src files. Once built, the doc is written to `openapi/openapi.json`
+- `app.js` - The entry point for the application. Setup as an expressJS API however acts more like a serverless consumer (MoJ CP doesn't support Lambda)
+- `resources/testing` - Various sample data used for testing.
+- `services/s3` - Supports integration with AWS S3.
+- `services/sqs` - Supports integration with AWS SQS.
+- `services/logging` - Supports logging out to std out.
+- `services/pdf` - Supports PDF generation capabilities using PDF Kit.
+
+
+# Requirements
+- [Node.js 18.16.1 or later with npm](https://nodejs.org/en/download/releases/)
+- The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+
+Not mandatory but useful if using VSCode:
+- Prettier formatter extension
+- AWS Toolkit extension
+
+# Local development setup
+
+Download or clone this repository.
+Add an .env file containing:
+
+   ```
+    NODE_ENV='local'
+    APPLICATION_QUEUE_ID='http://localhost:4566/000000000000/application-queue'
+    TEMPUS_QUEUE_ID='http://localhost:4566/000000000000/tempus-queue'
+    S3_BUCKET='application-bucket'
+   ```
+
+Configure local AWS environment:
+
+The application service uses localstack for easy setup of AWS services and resources for local development. The setup can be found in the Makefile of this directory.
+
+Open this project directory in terminal and run:
+ - `make init` (if running for the first time)
+ - `make start`
+ - `make create-bucket`
+ - `make create-queues`
+ - `make upload-json`
+ - `make send-message`
+This will run in the `resources/testing/checkYourAnswers.json` test file by default, so for changing what your test data is, either update this file or update the reference to change which file gets uploaded in the Makefile.
+
+The above steps are the minimum required to upload to the bucket and send a message for consumption to the queue, there's some other supporting commands that can help debugging such as `purge-queue`, `list-objects`, `poll-tempus`.
+
+To check the localstack container is running, you can run `docker ps`
+
+Use `npm run start` to run the function locally to consume any messages in the localstack SQS queue. It polls every 30 seconds, so make sure you wait for that amount of time before giving up on it!
+
+# Test
+
+To run all tests with test coverage, use:
+`npx --no-install jest --ci --runInBand --bail --silent --coverage --projects jest.config.js`
+
+To run tests with a debugger attached, use the Run and Debug panel within VS code. The configurations for this can be adjusted in
+`.vscode/launch.json`

--- a/services/s3/index.js
+++ b/services/s3/index.js
@@ -77,9 +77,13 @@ function createS3Service() {
                     logger.error(unsupportedFileError);
                     rej(unsupportedFileError);
                 }
+
+                // for some reason when running locally, the key is expected to be `bucket/key`
+                // but when running in production, it is expected to be just `key`
+                const s3Key = process.env.NODE_ENV === 'local' ? `${bucket}/${key}` : key;
                 const command = new PutObjectCommand({
                     Bucket: bucket,
-                    Key: `${key}`,
+                    Key: s3Key,
                     Body: file,
                     ContentType: contentType,
                     ServerSideEncryption: 'aws:kms',


### PR DESCRIPTION
This PR Is purely for a README update, but there is one code changes associated (which should not have any affect other than for local development). This change is simply to prefix the upload location with the bucket when developing locally. For whatever reason, when mocking uploads via Localstack, the key input parameter is expected to be in the format of `bucket/key`, whereas when running in production, it's just `key`.