### PR TITLE
Chore/trivy scan updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ executors:
 jobs:
   build-for-test:
     docker:
-      - image: cimg/node:20.1.0
+      - image: cimg/node:20.16.0
     steps:
       - checkout
       - run:
@@ -37,7 +37,7 @@ jobs:
             - ./node_modules
   test:
     docker:
-      - image: cimg/node:20.1.0
+      - image: cimg/node:20.16.0
     steps:
       - attach_workspace:
           at: ./
@@ -48,7 +48,7 @@ jobs:
           command: npx --no-install jest --ci --runInBand --bail --silent --coverage --projects jest.config.js
   lint:
     docker:
-      - image: cimg/node:20.1.0
+      - image: cimg/node:20.16.0
     steps:
       - attach_workspace:
           at: ./
@@ -73,7 +73,9 @@ jobs:
             curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
       - run:
           name: Scan the local image with trivy
-          command: trivy image --exit-code 0 --no-progress cica/cica-repo-dev
+          command: |
+            trivy image --exit-code 0 --severity MEDIUM,HIGH --no-progress cica/cica-repo-dev
+            trivy image --exit-code 1 --severity CRITICAL --no-progress --show-suppressed cica/cica-repo-dev --vex trivy.openvex.json
       - run:
           name: Archive Docker Image
           command: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
                 "jest": "^28.1.3",
                 "json-schema-ref-parser": "^6.1.0",
                 "lint-staged": "^11.0.0",
-                "nodemon": "^2.0.22",
+                "nodemon": "^3.1.4",
                 "prettier": "^1.19.1",
                 "speccy": "github:wework/speccy#740d19d88935db7735250c16abc2ad09256b5854",
                 "yamljs": "^0.3.0"
@@ -9166,18 +9166,19 @@
             "dev": true
         },
         "node_modules/nodemon": {
-            "version": "2.0.22",
-            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
-            "integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.4.tgz",
+            "integrity": "sha512-wjPBbFhtpJwmIeY2yP7QF+UKzPfltVGtfce1g/bB15/8vCGZj8uxD62b/b9M9/WVgme0NZudpownKN+c0plXlQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chokidar": "^3.5.2",
-                "debug": "^3.2.7",
+                "debug": "^4",
                 "ignore-by-default": "^1.0.1",
                 "minimatch": "^3.1.2",
                 "pstree.remy": "^1.1.8",
-                "semver": "^5.7.1",
-                "simple-update-notifier": "^1.0.7",
+                "semver": "^7.5.3",
+                "simple-update-notifier": "^2.0.0",
                 "supports-color": "^5.5.0",
                 "touch": "^3.1.0",
                 "undefsafe": "^2.0.5"
@@ -9186,20 +9187,11 @@
                 "nodemon": "bin/nodemon.js"
             },
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">=10"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/nodemon"
-            }
-        },
-        "node_modules/nodemon/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "^2.1.1"
             }
         },
         "node_modules/nodemon/node_modules/has-flag": {
@@ -9212,12 +9204,16 @@
             }
         },
         "node_modules/nodemon/node_modules/semver": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
+            "license": "ISC",
             "bin": {
-                "semver": "bin/semver"
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/nodemon/node_modules/supports-color": {
@@ -10958,24 +10954,29 @@
             "dev": true
         },
         "node_modules/simple-update-notifier": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
-            "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+            "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "semver": "~7.0.0"
+                "semver": "^7.5.3"
             },
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">=10"
             }
         },
         "node_modules/simple-update-notifier/node_modules/semver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-            "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/sinon": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,192 +75,270 @@
             }
         },
         "node_modules/@aws-crypto/crc32": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-            "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+            "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
-        },
-        "node_modules/@aws-crypto/crc32/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/crc32c": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
-            "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+            "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
+                "tslib": "^2.6.2"
             }
-        },
-        "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-crypto/ie11-detection": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-            "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-            "dependencies": {
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/sha1-browser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
-            "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+            "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/ie11-detection": "^3.0.0",
-                "@aws-crypto/supports-web-crypto": "^3.0.0",
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
                 "@aws-sdk/util-locate-window": "^3.0.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
             }
         },
-        "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/@aws-crypto/sha256-browser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-            "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/ie11-detection": "^3.0.0",
-                "@aws-crypto/sha256-js": "^3.0.0",
-                "@aws-crypto/supports-web-crypto": "^3.0.0",
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
                 "@aws-sdk/util-locate-window": "^3.0.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
             }
         },
-        "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/@aws-crypto/sha256-js": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-            "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
-        },
-        "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-            "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "tslib": "^1.11.1"
+                "tslib": "^2.6.2"
             }
-        },
-        "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/util": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-            "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
             }
         },
-        "node_modules/@aws-crypto/util/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.577.0.tgz",
-            "integrity": "sha512-mQYXwn6E4Rwggn6teF6EIWJtK8jsKcxnPj2QVETkSmD8QaFLm4g/DgLPdamDE97UI8k1k0cmWqXcTOLIaZ7wQg==",
+            "version": "3.637.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.637.0.tgz",
+            "integrity": "sha512-y6UC94fsMvhKbf0dzfnjVP1HePeGjplfcYfilZU1COIJLyTkMcUv4XcT4I407CGIrvgEafONHkiC09ygqUauNA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha1-browser": "3.0.0",
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sso-oidc": "3.577.0",
-                "@aws-sdk/client-sts": "3.577.0",
-                "@aws-sdk/core": "3.576.0",
-                "@aws-sdk/credential-provider-node": "3.577.0",
-                "@aws-sdk/middleware-bucket-endpoint": "3.577.0",
-                "@aws-sdk/middleware-expect-continue": "3.577.0",
-                "@aws-sdk/middleware-flexible-checksums": "3.577.0",
-                "@aws-sdk/middleware-host-header": "3.577.0",
-                "@aws-sdk/middleware-location-constraint": "3.577.0",
-                "@aws-sdk/middleware-logger": "3.577.0",
-                "@aws-sdk/middleware-recursion-detection": "3.577.0",
-                "@aws-sdk/middleware-sdk-s3": "3.577.0",
-                "@aws-sdk/middleware-signing": "3.577.0",
-                "@aws-sdk/middleware-ssec": "3.577.0",
-                "@aws-sdk/middleware-user-agent": "3.577.0",
-                "@aws-sdk/region-config-resolver": "3.577.0",
-                "@aws-sdk/signature-v4-multi-region": "3.577.0",
-                "@aws-sdk/types": "3.577.0",
-                "@aws-sdk/util-endpoints": "3.577.0",
-                "@aws-sdk/util-user-agent-browser": "3.577.0",
-                "@aws-sdk/util-user-agent-node": "3.577.0",
-                "@aws-sdk/xml-builder": "3.575.0",
-                "@smithy/config-resolver": "^3.0.0",
-                "@smithy/core": "^2.0.0",
-                "@smithy/eventstream-serde-browser": "^3.0.0",
-                "@smithy/eventstream-serde-config-resolver": "^3.0.0",
-                "@smithy/eventstream-serde-node": "^3.0.0",
-                "@smithy/fetch-http-handler": "^3.0.0",
-                "@smithy/hash-blob-browser": "^3.0.0",
-                "@smithy/hash-node": "^3.0.0",
-                "@smithy/hash-stream-node": "^3.0.0",
-                "@smithy/invalid-dependency": "^3.0.0",
-                "@smithy/md5-js": "^3.0.0",
-                "@smithy/middleware-content-length": "^3.0.0",
-                "@smithy/middleware-endpoint": "^3.0.0",
-                "@smithy/middleware-retry": "^3.0.0",
-                "@smithy/middleware-serde": "^3.0.0",
-                "@smithy/middleware-stack": "^3.0.0",
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/node-http-handler": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/smithy-client": "^3.0.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/url-parser": "^3.0.0",
+                "@aws-crypto/sha1-browser": "5.2.0",
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.637.0",
+                "@aws-sdk/client-sts": "3.637.0",
+                "@aws-sdk/core": "3.635.0",
+                "@aws-sdk/credential-provider-node": "3.637.0",
+                "@aws-sdk/middleware-bucket-endpoint": "3.620.0",
+                "@aws-sdk/middleware-expect-continue": "3.620.0",
+                "@aws-sdk/middleware-flexible-checksums": "3.620.0",
+                "@aws-sdk/middleware-host-header": "3.620.0",
+                "@aws-sdk/middleware-location-constraint": "3.609.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.620.0",
+                "@aws-sdk/middleware-sdk-s3": "3.635.0",
+                "@aws-sdk/middleware-ssec": "3.609.0",
+                "@aws-sdk/middleware-user-agent": "3.637.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/signature-v4-multi-region": "3.635.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.637.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@aws-sdk/xml-builder": "3.609.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.4.0",
+                "@smithy/eventstream-serde-browser": "^3.0.6",
+                "@smithy/eventstream-serde-config-resolver": "^3.0.3",
+                "@smithy/eventstream-serde-node": "^3.0.5",
+                "@smithy/fetch-http-handler": "^3.2.4",
+                "@smithy/hash-blob-browser": "^3.1.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/hash-stream-node": "^3.1.2",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/md5-js": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.5",
+                "@smithy/middleware-endpoint": "^3.1.0",
+                "@smithy/middleware-retry": "^3.0.15",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-body-length-browser": "^3.0.0",
                 "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.0",
-                "@smithy/util-defaults-mode-node": "^3.0.0",
-                "@smithy/util-endpoints": "^2.0.0",
-                "@smithy/util-retry": "^3.0.0",
-                "@smithy/util-stream": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.15",
+                "@smithy/util-defaults-mode-node": "^3.0.15",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-stream": "^3.1.3",
                 "@smithy/util-utf8": "^3.0.0",
-                "@smithy/util-waiter": "^3.0.0",
+                "@smithy/util-waiter": "^3.1.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -268,51 +346,52 @@
             }
         },
         "node_modules/@aws-sdk/client-sqs": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.577.0.tgz",
-            "integrity": "sha512-h3Gquz0BrR7aN5n4mTPp59rxcpGVn4j6HV5TuhMbsfnZet2Aee1c+JlXdWRNkf3Vfrb1tmt9EF2b7jNpYRf3pw==",
+            "version": "3.637.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.637.0.tgz",
+            "integrity": "sha512-0slT2OCa8uOottHFjIBD9EuTotu3Qdzp7Z7PqtkSqQdbXxC8CFsDLNfZVqpU8o/+mf79I2fJK21pEPhBnm654g==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sso-oidc": "3.577.0",
-                "@aws-sdk/client-sts": "3.577.0",
-                "@aws-sdk/core": "3.576.0",
-                "@aws-sdk/credential-provider-node": "3.577.0",
-                "@aws-sdk/middleware-host-header": "3.577.0",
-                "@aws-sdk/middleware-logger": "3.577.0",
-                "@aws-sdk/middleware-recursion-detection": "3.577.0",
-                "@aws-sdk/middleware-sdk-sqs": "3.577.0",
-                "@aws-sdk/middleware-user-agent": "3.577.0",
-                "@aws-sdk/region-config-resolver": "3.577.0",
-                "@aws-sdk/types": "3.577.0",
-                "@aws-sdk/util-endpoints": "3.577.0",
-                "@aws-sdk/util-user-agent-browser": "3.577.0",
-                "@aws-sdk/util-user-agent-node": "3.577.0",
-                "@smithy/config-resolver": "^3.0.0",
-                "@smithy/core": "^2.0.0",
-                "@smithy/fetch-http-handler": "^3.0.0",
-                "@smithy/hash-node": "^3.0.0",
-                "@smithy/invalid-dependency": "^3.0.0",
-                "@smithy/md5-js": "^3.0.0",
-                "@smithy/middleware-content-length": "^3.0.0",
-                "@smithy/middleware-endpoint": "^3.0.0",
-                "@smithy/middleware-retry": "^3.0.0",
-                "@smithy/middleware-serde": "^3.0.0",
-                "@smithy/middleware-stack": "^3.0.0",
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/node-http-handler": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/smithy-client": "^3.0.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/url-parser": "^3.0.0",
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.637.0",
+                "@aws-sdk/client-sts": "3.637.0",
+                "@aws-sdk/core": "3.635.0",
+                "@aws-sdk/credential-provider-node": "3.637.0",
+                "@aws-sdk/middleware-host-header": "3.620.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.620.0",
+                "@aws-sdk/middleware-sdk-sqs": "3.635.0",
+                "@aws-sdk/middleware-user-agent": "3.637.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.637.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.4.0",
+                "@smithy/fetch-http-handler": "^3.2.4",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/md5-js": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.5",
+                "@smithy/middleware-endpoint": "^3.1.0",
+                "@smithy/middleware-retry": "^3.0.15",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-body-length-browser": "^3.0.0",
                 "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.0",
-                "@smithy/util-defaults-mode-node": "^3.0.0",
-                "@smithy/util-endpoints": "^2.0.0",
-                "@smithy/util-middleware": "^3.0.0",
-                "@smithy/util-retry": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.15",
+                "@smithy/util-defaults-mode-node": "^3.0.15",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -321,46 +400,47 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.577.0.tgz",
-            "integrity": "sha512-BwujdXrydlk6UEyPmewm5GqG4nkQ6OVyRhS/SyZP/6UKSFv2/sf391Cmz0hN0itUTH1rR4XeLln8XCOtarkrzg==",
+            "version": "3.637.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.637.0.tgz",
+            "integrity": "sha512-+KjLvgX5yJYROWo3TQuwBJlHCY0zz9PsLuEolmXQn0BVK1L/m9GteZHtd+rEdAoDGBpE0Xqjy1oz5+SmtsaRUw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/core": "3.576.0",
-                "@aws-sdk/middleware-host-header": "3.577.0",
-                "@aws-sdk/middleware-logger": "3.577.0",
-                "@aws-sdk/middleware-recursion-detection": "3.577.0",
-                "@aws-sdk/middleware-user-agent": "3.577.0",
-                "@aws-sdk/region-config-resolver": "3.577.0",
-                "@aws-sdk/types": "3.577.0",
-                "@aws-sdk/util-endpoints": "3.577.0",
-                "@aws-sdk/util-user-agent-browser": "3.577.0",
-                "@aws-sdk/util-user-agent-node": "3.577.0",
-                "@smithy/config-resolver": "^3.0.0",
-                "@smithy/core": "^2.0.0",
-                "@smithy/fetch-http-handler": "^3.0.0",
-                "@smithy/hash-node": "^3.0.0",
-                "@smithy/invalid-dependency": "^3.0.0",
-                "@smithy/middleware-content-length": "^3.0.0",
-                "@smithy/middleware-endpoint": "^3.0.0",
-                "@smithy/middleware-retry": "^3.0.0",
-                "@smithy/middleware-serde": "^3.0.0",
-                "@smithy/middleware-stack": "^3.0.0",
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/node-http-handler": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/smithy-client": "^3.0.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/url-parser": "^3.0.0",
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.635.0",
+                "@aws-sdk/middleware-host-header": "3.620.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.620.0",
+                "@aws-sdk/middleware-user-agent": "3.637.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.637.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.4.0",
+                "@smithy/fetch-http-handler": "^3.2.4",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.5",
+                "@smithy/middleware-endpoint": "^3.1.0",
+                "@smithy/middleware-retry": "^3.0.15",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-body-length-browser": "^3.0.0",
                 "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.0",
-                "@smithy/util-defaults-mode-node": "^3.0.0",
-                "@smithy/util-endpoints": "^2.0.0",
-                "@smithy/util-middleware": "^3.0.0",
-                "@smithy/util-retry": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.15",
+                "@smithy/util-defaults-mode-node": "^3.0.15",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -369,98 +449,102 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.577.0.tgz",
-            "integrity": "sha512-njmKSPDWueWWYVFpFcZ2P3fI6/pdQVDa0FgCyYZhOnJLgEHZIcBBg1AsnkVWacBuLopp9XVt2m+7hO6ugY1/1g==",
+            "version": "3.637.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.637.0.tgz",
+            "integrity": "sha512-27bHALN6Qb6m6KZmPvRieJ/QRlj1lyac/GT2Rn5kJpre8Mpp+yxrtvp3h9PjNBty4lCeFEENfY4dGNSozBuBcw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.577.0",
-                "@aws-sdk/core": "3.576.0",
-                "@aws-sdk/credential-provider-node": "3.577.0",
-                "@aws-sdk/middleware-host-header": "3.577.0",
-                "@aws-sdk/middleware-logger": "3.577.0",
-                "@aws-sdk/middleware-recursion-detection": "3.577.0",
-                "@aws-sdk/middleware-user-agent": "3.577.0",
-                "@aws-sdk/region-config-resolver": "3.577.0",
-                "@aws-sdk/types": "3.577.0",
-                "@aws-sdk/util-endpoints": "3.577.0",
-                "@aws-sdk/util-user-agent-browser": "3.577.0",
-                "@aws-sdk/util-user-agent-node": "3.577.0",
-                "@smithy/config-resolver": "^3.0.0",
-                "@smithy/core": "^2.0.0",
-                "@smithy/fetch-http-handler": "^3.0.0",
-                "@smithy/hash-node": "^3.0.0",
-                "@smithy/invalid-dependency": "^3.0.0",
-                "@smithy/middleware-content-length": "^3.0.0",
-                "@smithy/middleware-endpoint": "^3.0.0",
-                "@smithy/middleware-retry": "^3.0.0",
-                "@smithy/middleware-serde": "^3.0.0",
-                "@smithy/middleware-stack": "^3.0.0",
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/node-http-handler": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/smithy-client": "^3.0.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/url-parser": "^3.0.0",
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.635.0",
+                "@aws-sdk/credential-provider-node": "3.637.0",
+                "@aws-sdk/middleware-host-header": "3.620.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.620.0",
+                "@aws-sdk/middleware-user-agent": "3.637.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.637.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.4.0",
+                "@smithy/fetch-http-handler": "^3.2.4",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.5",
+                "@smithy/middleware-endpoint": "^3.1.0",
+                "@smithy/middleware-retry": "^3.0.15",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-body-length-browser": "^3.0.0",
                 "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.0",
-                "@smithy/util-defaults-mode-node": "^3.0.0",
-                "@smithy/util-endpoints": "^2.0.0",
-                "@smithy/util-middleware": "^3.0.0",
-                "@smithy/util-retry": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.15",
+                "@smithy/util-defaults-mode-node": "^3.0.15",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.637.0"
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.577.0.tgz",
-            "integrity": "sha512-509Kklimva1XVlhGbpTpeX3kOP6ORpm44twJxDHpa9TURbmoaxj7veWlnLCbDorxDTrbsDghvYZshvcLsojVpg==",
+            "version": "3.637.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.637.0.tgz",
+            "integrity": "sha512-xUi7x4qDubtA8QREtlblPuAcn91GS/09YVEY/RwU7xCY0aqGuFwgszAANlha4OUIqva8oVj2WO4gJuG+iaSnhw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sso-oidc": "3.577.0",
-                "@aws-sdk/core": "3.576.0",
-                "@aws-sdk/credential-provider-node": "3.577.0",
-                "@aws-sdk/middleware-host-header": "3.577.0",
-                "@aws-sdk/middleware-logger": "3.577.0",
-                "@aws-sdk/middleware-recursion-detection": "3.577.0",
-                "@aws-sdk/middleware-user-agent": "3.577.0",
-                "@aws-sdk/region-config-resolver": "3.577.0",
-                "@aws-sdk/types": "3.577.0",
-                "@aws-sdk/util-endpoints": "3.577.0",
-                "@aws-sdk/util-user-agent-browser": "3.577.0",
-                "@aws-sdk/util-user-agent-node": "3.577.0",
-                "@smithy/config-resolver": "^3.0.0",
-                "@smithy/core": "^2.0.0",
-                "@smithy/fetch-http-handler": "^3.0.0",
-                "@smithy/hash-node": "^3.0.0",
-                "@smithy/invalid-dependency": "^3.0.0",
-                "@smithy/middleware-content-length": "^3.0.0",
-                "@smithy/middleware-endpoint": "^3.0.0",
-                "@smithy/middleware-retry": "^3.0.0",
-                "@smithy/middleware-serde": "^3.0.0",
-                "@smithy/middleware-stack": "^3.0.0",
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/node-http-handler": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/smithy-client": "^3.0.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/url-parser": "^3.0.0",
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.637.0",
+                "@aws-sdk/core": "3.635.0",
+                "@aws-sdk/credential-provider-node": "3.637.0",
+                "@aws-sdk/middleware-host-header": "3.620.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.620.0",
+                "@aws-sdk/middleware-user-agent": "3.637.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.637.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.4.0",
+                "@smithy/fetch-http-handler": "^3.2.4",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.5",
+                "@smithy/middleware-endpoint": "^3.1.0",
+                "@smithy/middleware-retry": "^3.0.15",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-body-length-browser": "^3.0.0",
                 "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.0",
-                "@smithy/util-defaults-mode-node": "^3.0.0",
-                "@smithy/util-endpoints": "^2.0.0",
-                "@smithy/util-middleware": "^3.0.0",
-                "@smithy/util-retry": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.15",
+                "@smithy/util-defaults-mode-node": "^3.0.15",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -469,16 +553,20 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.576.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.576.0.tgz",
-            "integrity": "sha512-KDvDlbeipSTIf+ffKtTg1m419TK7s9mZSWC8bvuZ9qx6/sjQFOXIKOVqyuli6DnfxGbvRcwoRuY99OcCH1N/0w==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.635.0.tgz",
+            "integrity": "sha512-i1x/E/sgA+liUE1XJ7rj1dhyXpAKO1UKFUcTTHXok2ARjWTvszHnSXMOsB77aPbmn0fUp1JTx2kHUAZ1LVt5Bg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^2.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/signature-v4": "^3.0.0",
-                "@smithy/smithy-client": "^3.0.0",
-                "@smithy/types": "^3.0.0",
-                "fast-xml-parser": "4.2.5",
+                "@smithy/core": "^2.4.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/signature-v4": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "fast-xml-parser": "4.4.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -486,13 +574,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.577.0.tgz",
-            "integrity": "sha512-Jxu255j0gToMGEiqufP8ZtKI8HW90lOLjwJ3LrdlD/NLsAY0tOQf1fWc53u28hWmmNGMxmCrL2p66IOgMDhDUw==",
+            "version": "3.620.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+            "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/property-provider": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -500,18 +589,19 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.577.0.tgz",
-            "integrity": "sha512-n++yhCp67b9+ZRGEdY1jhamB5E/O+QsIDOPSuRmdaSGMCOd82oUEKPgIVEU1bkqxDsBxgiEWuvtfhK6sNiDS0A==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.635.0.tgz",
+            "integrity": "sha512-iJyRgEjOCQlBMXqtwPLIKYc7Bsc6nqjrZybdMDenPDa+kmLg7xh8LxHsu9088e+2/wtLicE34FsJJIfzu3L82g==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/fetch-http-handler": "^3.0.0",
-                "@smithy/node-http-handler": "^3.0.0",
-                "@smithy/property-provider": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/smithy-client": "^3.0.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/util-stream": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/fetch-http-handler": "^3.2.4",
+                "@smithy/node-http-handler": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-stream": "^3.1.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -519,44 +609,47 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.577.0.tgz",
-            "integrity": "sha512-q7lHPtv6BjRvChUE3m0tIaEZKxPTaZ1B3lKxGYsFl3VLAu5N8yGCUKwuA1izf4ucT+LyKscVGqK6VDZx1ev3nw==",
+            "version": "3.637.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.637.0.tgz",
+            "integrity": "sha512-h+PFCWfZ0Q3Dx84SppET/TFpcQHmxFW8/oV9ArEvMilw4EBN+IlxgbL0CnHwjHW64szcmrM0mbebjEfHf4FXmw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.577.0",
-                "@aws-sdk/credential-provider-process": "3.577.0",
-                "@aws-sdk/credential-provider-sso": "3.577.0",
-                "@aws-sdk/credential-provider-web-identity": "3.577.0",
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/credential-provider-imds": "^3.0.0",
-                "@smithy/property-provider": "^3.0.0",
-                "@smithy/shared-ini-file-loader": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/credential-provider-env": "3.620.1",
+                "@aws-sdk/credential-provider-http": "3.635.0",
+                "@aws-sdk/credential-provider-process": "3.620.1",
+                "@aws-sdk/credential-provider-sso": "3.637.0",
+                "@aws-sdk/credential-provider-web-identity": "3.621.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/credential-provider-imds": "^3.2.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.577.0"
+                "@aws-sdk/client-sts": "^3.637.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.577.0.tgz",
-            "integrity": "sha512-epZ1HOMsrXBNczc0HQpv0VMjqAEpc09DUA7Rg3gUJfn8umhML7A7bXnUyqPA+S54q397UYg1leQKdSn23OiwQQ==",
+            "version": "3.637.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.637.0.tgz",
+            "integrity": "sha512-yoEhoxJJfs7sPVQ6Is939BDQJZpZCoUgKr/ySse4YKOZ24t4VqgHA6+wV7rYh+7IW24Rd91UTvEzSuHYTlxlNA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.577.0",
-                "@aws-sdk/credential-provider-http": "3.577.0",
-                "@aws-sdk/credential-provider-ini": "3.577.0",
-                "@aws-sdk/credential-provider-process": "3.577.0",
-                "@aws-sdk/credential-provider-sso": "3.577.0",
-                "@aws-sdk/credential-provider-web-identity": "3.577.0",
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/credential-provider-imds": "^3.0.0",
-                "@smithy/property-provider": "^3.0.0",
-                "@smithy/shared-ini-file-loader": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/credential-provider-env": "3.620.1",
+                "@aws-sdk/credential-provider-http": "3.635.0",
+                "@aws-sdk/credential-provider-ini": "3.637.0",
+                "@aws-sdk/credential-provider-process": "3.620.1",
+                "@aws-sdk/credential-provider-sso": "3.637.0",
+                "@aws-sdk/credential-provider-web-identity": "3.621.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/credential-provider-imds": "^3.2.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -564,14 +657,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.577.0.tgz",
-            "integrity": "sha512-Gin6BWtOiXxIgITrJ3Nwc+Y2P1uVT6huYR4EcbA/DJUPWyO0n9y5UFLewPvVbLkRn15JeEqErBLUrHclkiOKtw==",
+            "version": "3.620.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+            "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/property-provider": "^3.0.0",
-                "@smithy/shared-ini-file-loader": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -579,16 +673,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.577.0.tgz",
-            "integrity": "sha512-iVm5SQvS7EgZTJsRaqUOmDQpBQPPPat42SCbWFvFQOLrl8qewq8OP94hFS5w2mP62zngeYzqhJnDel79HXbxew==",
+            "version": "3.637.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.637.0.tgz",
+            "integrity": "sha512-Mvz+h+e62/tl+dVikLafhv+qkZJ9RUb8l2YN/LeKMWkxQylPT83CPk9aimVhCV89zth1zpREArl97+3xsfgQvA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.577.0",
-                "@aws-sdk/token-providers": "3.577.0",
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/property-provider": "^3.0.0",
-                "@smithy/shared-ini-file-loader": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/client-sso": "3.637.0",
+                "@aws-sdk/token-providers": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -596,32 +691,34 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.577.0.tgz",
-            "integrity": "sha512-ZGHGNRaCtJJmszb9UTnC7izNCtRUttdPlLdMkh41KPS32vfdrBDHs1JrpbZijItRj1xKuOXsiYSXLAaHGcLh8Q==",
+            "version": "3.621.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+            "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/property-provider": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.577.0"
+                "@aws-sdk/client-sts": "^3.621.0"
             }
         },
         "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.577.0.tgz",
-            "integrity": "sha512-twlkNX2VofM6kHXzDEiJOiYCc9tVABe5cbyxMArRWscIsCWG9mamPhC77ezG4XsN9dFEwVdxEYD5Crpm/5EUiw==",
+            "version": "3.620.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.620.0.tgz",
+            "integrity": "sha512-eGLL0W6L3HDb3OACyetZYOWpHJ+gLo0TehQKeQyy2G8vTYXqNTeqYhuI6up9HVjBzU9eQiULVQETmgQs7TFaRg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
+                "@aws-sdk/types": "3.609.0",
                 "@aws-sdk/util-arn-parser": "3.568.0",
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-config-provider": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -630,13 +727,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-expect-continue": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.577.0.tgz",
-            "integrity": "sha512-6dPp8Tv4F0of4un5IAyG6q++GrRrNQQ4P2NAMB1W0VO4JoEu1C8GievbbDLi88TFIFmtKpnHB0ODCzwnoe8JsA==",
+            "version": "3.620.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.620.0.tgz",
+            "integrity": "sha512-QXeRFMLfyQ31nAHLbiTLtk0oHzG9QLMaof5jIfqcUwnOkO8YnQdeqzakrg1Alpy/VQ7aqzIi8qypkBe2KXZz0A==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -644,16 +742,17 @@
             }
         },
         "node_modules/@aws-sdk/middleware-flexible-checksums": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.577.0.tgz",
-            "integrity": "sha512-IHAUEipIfagjw92LV8SOSBiCF7ZnqfHcw14IkcZW2/mfrCy1Fh/k40MoS/t3Tro2tQ91rgQPwUoSgB/QCi2Org==",
+            "version": "3.620.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.620.0.tgz",
+            "integrity": "sha512-ftz+NW7qka2sVuwnnO1IzBku5ccP+s5qZGeRTPgrKB7OzRW85gthvIo1vQR2w+OwHFk7WJbbhhWwbCbktnP4UA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@aws-crypto/crc32c": "3.0.0",
-                "@aws-sdk/types": "3.577.0",
+                "@aws-crypto/crc32": "5.2.0",
+                "@aws-crypto/crc32c": "5.2.0",
+                "@aws-sdk/types": "3.609.0",
                 "@smithy/is-array-buffer": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -662,13 +761,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.577.0.tgz",
-            "integrity": "sha512-9ca5MJz455CODIVXs0/sWmJm7t3QO4EUa1zf8pE8grLpzf0J94bz/skDWm37Pli13T3WaAQBHCTiH2gUVfCsWg==",
+            "version": "3.620.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+            "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -676,12 +776,13 @@
             }
         },
         "node_modules/@aws-sdk/middleware-location-constraint": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.577.0.tgz",
-            "integrity": "sha512-DKPTD2D2s+t2QUo/IXYtVa/6Un8GZ+phSTBkyBNx2kfZz4Kwavhl/JJzSqTV3GfCXkVdFu7CrjoX7BZ6qWeTUA==",
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.609.0.tgz",
+            "integrity": "sha512-xzsdoTkszGVqGVPjUmgoP7TORiByLueMHieI1fhQL888WPdqctwAx3ES6d/bA9Q/i8jnc6hs+Fjhy8UvBTkE9A==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -689,12 +790,13 @@
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.577.0.tgz",
-            "integrity": "sha512-aPFGpGjTZcJYk+24bg7jT4XdIp42mFXSuPt49lw5KygefLyJM/sB0bKKqPYYivW0rcuZ9brQ58eZUNthrzYAvg==",
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+            "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -702,13 +804,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.577.0.tgz",
-            "integrity": "sha512-pn3ZVEd2iobKJlR3H+bDilHjgRnNrQ6HMmK9ZzZw89Ckn3Dcbv48xOv4RJvu0aU8SDLl/SNCxppKjeLDTPGBNA==",
+            "version": "3.620.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+            "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -716,18 +819,24 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.577.0.tgz",
-            "integrity": "sha512-/t8Shvy6lGIRdTEKG6hA8xy+oon/CDF5H8Ksms/cd/uvIy/MYbNjOJ/Arwk8H5W6LB4DP/1O+tOzOpGx1MCufA==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.635.0.tgz",
+            "integrity": "sha512-RLdYJPEV4JL/7NBoFUs7VlP90X++5FlJdxHz0DzCjmiD3qCviKy+Cym3qg1gBgHwucs5XisuClxDrGokhAdTQw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
+                "@aws-sdk/core": "3.635.0",
+                "@aws-sdk/types": "3.609.0",
                 "@aws-sdk/util-arn-parser": "3.568.0",
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/signature-v4": "^3.0.0",
-                "@smithy/smithy-client": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/core": "^2.4.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/signature-v4": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-stream": "^3.1.3",
+                "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -735,13 +844,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-sqs": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.577.0.tgz",
-            "integrity": "sha512-XUOIFL3xRLgePbIzH4t/tOI9S/aGwXcTuR/hefkkXOZlTLh3LOHtgyRAPOiMGedmMMoCLuRY1AGKTOce5vuPYQ==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.635.0.tgz",
+            "integrity": "sha512-EsrTqso8dBeugdKYyKmF2faqplYoPvW7YNE5wttgFCeSn4HvG8lh+oGt9/ofawTy0GLkQG2Z5eKhUAgYSrP2Ww==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/smithy-client": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-hex-encoding": "^3.0.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
@@ -750,30 +860,14 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.577.0.tgz",
-            "integrity": "sha512-QS/dh3+NqZbXtY0j/DZ867ogP413pG5cFGqBy9OeOhDMsolcwLrQbi0S0c621dc1QNq+er9ffaMhZ/aPkyXXIg==",
-            "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/property-provider": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/signature-v4": "^3.0.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-ssec": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.577.0.tgz",
-            "integrity": "sha512-i2BPJR+rp8xmRVIGc0h1kDRFcM2J9GnClqqpc+NLSjmYadlcg4mPklisz9HzwFVcRPJ5XcGf3U4BYs5G8+iTyg==",
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.609.0.tgz",
+            "integrity": "sha512-GZSD1s7+JswWOTamVap79QiDaIV7byJFssBW68GYjyRS5EBjNfwA/8s+6uE6g39R3ojyTbYOmvcANoZEhSULXg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -781,14 +875,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.577.0.tgz",
-            "integrity": "sha512-P55HAXgwmiHHpFx5JEPvOnAbfhN7v6sWv9PBQs+z2tC7QiBcPS0cdJR6PfV7J1n4VPK52/OnrK3l9VxdQ7Ms0g==",
+            "version": "3.637.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.637.0.tgz",
+            "integrity": "sha512-EYo0NE9/da/OY8STDsK2LvM4kNa79DBsf4YVtaG4P5pZ615IeFsD8xOHZeuJmUrSMlVQ8ywPRX7WMucUybsKug==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@aws-sdk/util-endpoints": "3.577.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.637.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -796,15 +891,16 @@
             }
         },
         "node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.577.0.tgz",
-            "integrity": "sha512-4ChCFACNwzqx/xjg3zgFcW8Ali6R9C95cFECKWT/7CUM1D0MGvkclSH2cLarmHCmJgU6onKkJroFtWp0kHhgyg==",
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+            "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -812,15 +908,16 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.577.0.tgz",
-            "integrity": "sha512-mMykGRFBYmlDcMhdbhNM0z1JFUaYYZ8r9WV7Dd0T2PWELv2brSAjDAOBHdJLHObDMYRnM6H0/Y974qTl3icEcQ==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.635.0.tgz",
+            "integrity": "sha512-J6QY4/invOkpogCHjSaDON1hF03viPpOnsrzVuCvJMmclS/iG62R4EY0wq1alYll0YmSdmKlpJwHMWwGtqK63Q==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-sdk-s3": "3.577.0",
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/signature-v4": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/middleware-sdk-s3": "3.635.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/signature-v4": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -828,29 +925,31 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.577.0.tgz",
-            "integrity": "sha512-0CkIZpcC3DNQJQ1hDjm2bdSy/Xjs7Ny5YvSsacasGOkNfk+FdkiQy6N67bZX3Zbc9KIx+Nz4bu3iDeNSNplnnQ==",
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+            "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/property-provider": "^3.0.0",
-                "@smithy/shared-ini-file-loader": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sso-oidc": "^3.577.0"
+                "@aws-sdk/client-sso-oidc": "^3.614.0"
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.577.0.tgz",
-            "integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+            "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -861,6 +960,7 @@
             "version": "3.568.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.568.0.tgz",
             "integrity": "sha512-XUKJWWo+KOB7fbnPP0+g/o5Ulku/X53t7i/h+sPHr5xxYTJJ9CYnbToo95mzxe7xWvkLrsNtJ8L+MnNn9INs2w==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -869,13 +969,14 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.577.0.tgz",
-            "integrity": "sha512-FjuUz1Kdy4Zly2q/c58tpdqHd6z7iOdU/caYzoc8jwgAHBDBbIJNQLCU9hXJnPV2M8pWxQDyIZsoVwtmvErPzw==",
+            "version": "3.637.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.637.0.tgz",
+            "integrity": "sha512-pAqOKUHeVWHEXXDIp/qoMk/6jyxIb6GGjnK1/f8dKHtKIEs4tKsnnL563gceEvdad53OPXIt86uoevCcCzmBnw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/util-endpoints": "^2.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-endpoints": "^2.0.5",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -886,6 +987,7 @@
             "version": "3.568.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
             "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -907,24 +1009,26 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.577.0.tgz",
-            "integrity": "sha512-zEAzHgR6HWpZOH7xFgeJLc6/CzMcx4nxeQolZxVZoB5pPaJd3CjyRhZN0xXeZB0XIRCWmb4yJBgyiugXLNMkLA==",
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+            "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.577.0.tgz",
-            "integrity": "sha512-XqvtFjbSMtycZTWVwDe8DRWovuoMbA54nhUoZwVU6rW9OSD6NZWGR512BUGHFaWzW0Wg8++Dj10FrKTG2XtqfA==",
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+            "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -939,20 +1043,13 @@
                 }
             }
         },
-        "node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "3.259.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-            "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            }
-        },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.575.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.575.0.tgz",
-            "integrity": "sha512-cWgAwmbFYNCFzPwxL705+lWps0F3ZvOckufd2KKoEZUmtpVw9/txUXNrPySUXSmRTSRhoatIMABNfStWR043bQ==",
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.609.0.tgz",
+            "integrity": "sha512-l9XxNcA4HX98rwCC2/KoiWcmEiRfZe4G+mYwDbCFT87JIMj6GBhLDkAzr/W8KAaA2IDr8Vc6J8fZPgVulxxfMA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2266,11 +2363,12 @@
             "dev": true
         },
         "node_modules/@smithy/abort-controller": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.0.tgz",
-            "integrity": "sha512-p6GlFGBt9K4MYLu72YuJ523NVR4A8oHlC5M2JO6OmQqN8kAc/uh1JqLE+FizTokrSJGg0CSvC+BrsmGzKtsZKA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+            "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2281,6 +2379,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-3.0.0.tgz",
             "integrity": "sha512-sbnURCwjF0gSToGlsBiAmd1lRCmSn72nu9axfJu5lIx6RUEgHu6GwTMbqCdhQSi0Pumcm5vFxsi9XWXb2mTaoA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             }
@@ -2289,20 +2388,22 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.0.tgz",
             "integrity": "sha512-VDkpCYW+peSuM4zJip5WDfqvg2Mo/e8yxOv3VF1m11y7B8KKMKVFtmZWDe36Fvk8rGuWrPZHHXZ7rR7uM5yWyg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/util-base64": "^3.0.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@smithy/config-resolver": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.0.tgz",
-            "integrity": "sha512-2GzOfADwYLQugYkKQhIyZyQlM05K+tMKvRnc6eFfZcpJGRfKoMUMYdPlBKmqHwQFXQKBrGV6cxL9oymWgDzvFw==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+            "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2310,17 +2411,20 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.0.1.tgz",
-            "integrity": "sha512-rcMkjvwxH/bER+oZUPR0yTA0ELD6m3A+d92+CFkdF6HJFCBB1bXo7P5pm21L66XwTN01B6bUhSCQ7cymWRD8zg==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.0.tgz",
+            "integrity": "sha512-cHXq+FneIF/KJbt4q4pjN186+Jf4ZB0ZOqEaZMBhT79srEyGDDBV31NqBRBjazz8ppQ1bJbDJMY9ba5wKFV36w==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-endpoint": "^3.0.0",
-                "@smithy/middleware-retry": "^3.0.1",
-                "@smithy/middleware-serde": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/smithy-client": "^3.0.1",
-                "@smithy/types": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
+                "@smithy/middleware-endpoint": "^3.1.0",
+                "@smithy/middleware-retry": "^3.0.15",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2328,14 +2432,15 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.0.0.tgz",
-            "integrity": "sha512-lfmBiFQcA3FsDAPxNfY0L7CawcWtbyWsBOHo34nF095728JLkBX4Y9q/VPPE2r7fqMVK+drmDigqE2/SSQeVRA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+            "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/property-provider": "^3.0.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/url-parser": "^3.0.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2343,23 +2448,25 @@
             }
         },
         "node_modules/@smithy/eventstream-codec": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.0.0.tgz",
-            "integrity": "sha512-PUtyEA0Oik50SaEFCZ0WPVtF9tz/teze2fDptW6WRXl+RrEenH8UbEjudOz8iakiMl3lE3lCVqYf2Y+znL8QFQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.2.tgz",
+            "integrity": "sha512-0mBcu49JWt4MXhrhRAlxASNy0IjDRFU+aWNDRal9OtUJvJNiwDuyKMUONSOjLjSCeGwZaE0wOErdqULer8r7yw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-crypto/crc32": "5.2.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-hex-encoding": "^3.0.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@smithy/eventstream-serde-browser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.0.tgz",
-            "integrity": "sha512-NB7AFiPN4NxP/YCAnrvYR18z2/ZsiHiF7VtG30gshO9GbFrIb1rC8ep4NGpJSWrz6P64uhPXeo4M0UsCLnZKqw==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.6.tgz",
+            "integrity": "sha512-2hM54UWQUOrki4BtsUI1WzmD13/SeaqT/AB3EUJKbcver/WgKNaiJ5y5F5XXuVe6UekffVzuUDrBZVAA3AWRpQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/eventstream-serde-universal": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/eventstream-serde-universal": "^3.0.5",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2367,11 +2474,12 @@
             }
         },
         "node_modules/@smithy/eventstream-serde-config-resolver": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.0.tgz",
-            "integrity": "sha512-RUQG3vQ3LX7peqqHAbmayhgrF5aTilPnazinaSGF1P0+tgM3vvIRWPHmlLIz2qFqB9LqFIxditxc8O2Z6psrRw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.3.tgz",
+            "integrity": "sha512-NVTYjOuYpGfrN/VbRQgn31x73KDLfCXCsFdad8DiIc3IcdxL+dYA9zEQPyOP7Fy2QL8CPy2WE4WCUD+ZsLNfaQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2379,12 +2487,13 @@
             }
         },
         "node_modules/@smithy/eventstream-serde-node": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.0.tgz",
-            "integrity": "sha512-baRPdMBDMBExZXIUAoPGm/hntixjt/VFpU6+VmCyiYJYzRHRxoaI1MN+5XE+hIS8AJ2GCHLMFEIOLzq9xx1EgQ==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.5.tgz",
+            "integrity": "sha512-+upXvnHNyZP095s11jF5dhGw/Ihzqwl5G+/KtMnoQOpdfC3B5HYCcDVG9EmgkhJMXJlM64PyN5gjJl0uXFQehQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/eventstream-serde-universal": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/eventstream-serde-universal": "^3.0.5",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2392,12 +2501,13 @@
             }
         },
         "node_modules/@smithy/eventstream-serde-universal": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.0.tgz",
-            "integrity": "sha512-HNFfShmotWGeAoW4ujP8meV9BZavcpmerDbPIjkJbxKbN8RsUcpRQ/2OyIxWNxXNH2GWCAxuSB7ynmIGJlQ3Dw==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.5.tgz",
+            "integrity": "sha512-5u/nXbyoh1s4QxrvNre9V6vfyoLWuiVvvd5TlZjGThIikc3G+uNiG9uOTCWweSRjv1asdDIWK7nOmN7le4RYHQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/eventstream-codec": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/eventstream-codec": "^3.1.2",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2405,34 +2515,37 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.0.1.tgz",
-            "integrity": "sha512-uaH74i5BDj+rBwoQaXioKpI0SHBJFtOVwzrCpxZxphOW0ki5jhj7dXvDMYM2IJem8TpdFvS2iC08sjOblfFGFg==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+            "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/querystring-builder": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/querystring-builder": "^3.0.3",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-base64": "^3.0.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@smithy/hash-blob-browser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.0.0.tgz",
-            "integrity": "sha512-/Wbpdg+bwJvW7lxR/zpWAc1/x/YkcqguuF2bAzkJrvXriZu1vm8r+PUdE4syiVwQg7PPR2dXpi3CLBb9qRDaVQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.2.tgz",
+            "integrity": "sha512-hAbfqN2UbISltakCC2TP0kx4LqXBttEv2MqSPE98gVuDFMf05lU+TpC41QtqGP3Ff5A3GwZMPfKnEy0VmEUpmg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/chunked-blob-reader": "^3.0.0",
                 "@smithy/chunked-blob-reader-native": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@smithy/hash-node": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.0.tgz",
-            "integrity": "sha512-84qXstNemP3XS5jcof0el6+bDfjzuvhJPQTEfro3lgtbCtKgzPm3MgiS6ehXVPjeQ5+JS0HqmTz8f/RYfzHVxw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+            "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-buffer-from": "^3.0.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
@@ -2442,11 +2555,12 @@
             }
         },
         "node_modules/@smithy/hash-stream-node": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.0.0.tgz",
-            "integrity": "sha512-J0i7de+EgXDEGITD4fxzmMX8CyCNETTIRXlxjMiNUvvu76Xn3GJ31wQR85ynlPk2wI1lqoknAFJaD1fiNDlbIA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.2.tgz",
+            "integrity": "sha512-PBgDMeEdDzi6JxKwbfBtwQG9eT9cVwsf0dZzLXoJF4sHKHs5HEo/3lJWpn6jibfJwT34I1EBXpBnZE8AxAft6g==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -2455,11 +2569,12 @@
             }
         },
         "node_modules/@smithy/invalid-dependency": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
-            "integrity": "sha512-F6wBBaEFgJzj0s4KUlliIGPmqXemwP6EavgvDqYwCH40O5Xr2iMHvS8todmGVZtuJCorBkXsYLyTu4PuizVq5g==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+            "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             }
         },
@@ -2475,22 +2590,24 @@
             }
         },
         "node_modules/@smithy/md5-js": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.0.tgz",
-            "integrity": "sha512-Tm0vrrVzjlD+6RCQTx7D3Ls58S3FUH1ZCtU1MIh/qQmaOo1H9lMN2as6CikcEwgattnA9SURSdoJJ27xMcEfMA==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.3.tgz",
+            "integrity": "sha512-O/SAkGVwpWmelpj/8yDtsaVe6sINHLB1q8YE/+ZQbDxIw3SRLbTZuRaI10K12sVoENdnHqzPp5i3/H+BcZ3m3Q==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@smithy/middleware-content-length": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
-            "integrity": "sha512-3C4s4d/iGobgCtk2tnWW6+zSTOBg1PRAm2vtWZLdriwTroFbbWNSr3lcyzHdrQHnEXYCC5K52EbpfodaIUY8sg==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+            "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2498,16 +2615,17 @@
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.0.tgz",
-            "integrity": "sha512-aXOAWztw/5qAfp0NcA2OWpv6ZI/E+Dh9mByif7i91D/0iyYNUcKvskmXiowKESFkuZ7PIMd3VOR4fTibZDs2OQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+            "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-serde": "^3.0.0",
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/shared-ini-file-loader": "^3.0.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/url-parser": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-middleware": "^3.0.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2515,17 +2633,18 @@
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.1.tgz",
-            "integrity": "sha512-hBhSEuL841FhJBK/19WpaGk5YWSzFk/P2UaVjANGKRv3eYNO8Y1lANWgqnuPWjOyCEWMPr58vELFDWpxvRKANw==",
+            "version": "3.0.15",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+            "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/service-error-classification": "^3.0.0",
-                "@smithy/smithy-client": "^3.0.1",
-                "@smithy/types": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
-                "@smithy/util-retry": "^3.0.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/service-error-classification": "^3.0.3",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
                 "tslib": "^2.6.2",
                 "uuid": "^9.0.1"
             },
@@ -2534,11 +2653,12 @@
             }
         },
         "node_modules/@smithy/middleware-serde": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.0.tgz",
-            "integrity": "sha512-I1vKG1foI+oPgG9r7IMY1S+xBnmAn1ISqployvqkwHoSb8VPsngHDTOgYGYBonuOKndaWRUGJZrKYYLB+Ane6w==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+            "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2546,11 +2666,12 @@
             }
         },
         "node_modules/@smithy/middleware-stack": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.0.tgz",
-            "integrity": "sha512-+H0jmyfAyHRFXm6wunskuNAqtj7yfmwFB6Fp37enytp2q047/Od9xetEaUbluyImOlGnGpaVGaVfjwawSr+i6Q==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+            "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2558,13 +2679,14 @@
             }
         },
         "node_modules/@smithy/node-config-provider": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.0.0.tgz",
-            "integrity": "sha512-buqfaSdDh0zo62EPLf8rGDvcpKwGpO5ho4bXS2cdFhlOta7tBkWJt+O5uiaAeICfIOfPclNOndshDNSanX2X9g==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+            "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^3.0.0",
-                "@smithy/shared-ini-file-loader": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2572,14 +2694,15 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.0.tgz",
-            "integrity": "sha512-3trD4r7NOMygwLbUJo4eodyQuypAWr7uvPnebNJ9a70dQhVn+US8j/lCnvoJS6BXfZeF7PkkkI0DemVJw+n+eQ==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+            "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/querystring-builder": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/abort-controller": "^3.1.1",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/querystring-builder": "^3.0.3",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2587,11 +2710,12 @@
             }
         },
         "node_modules/@smithy/property-provider": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.0.0.tgz",
-            "integrity": "sha512-LmbPgHBswdXCrkWWuUwBm9w72S2iLWyC/5jet9/Y9cGHtzqxi+GVjfCfahkvNV4KXEwgnH8EMpcrD9RUYe0eLQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+            "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2599,11 +2723,12 @@
             }
         },
         "node_modules/@smithy/protocol-http": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.0.tgz",
-            "integrity": "sha512-qOQZOEI2XLWRWBO9AgIYuHuqjZ2csyr8/IlgFDHDNuIgLAMRx2Bl8ck5U5D6Vh9DPdoaVpuzwWMa0xcdL4O/AQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+            "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2611,11 +2736,12 @@
             }
         },
         "node_modules/@smithy/querystring-builder": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.0.tgz",
-            "integrity": "sha512-bW8Fi0NzyfkE0TmQphDXr1AmBDbK01cA4C1Z7ggwMAU5RDz5AAv/KmoRwzQAS0kxXNf/D2ALTEgwK0U2c4LtRg==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+            "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-uri-escape": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -2624,11 +2750,12 @@
             }
         },
         "node_modules/@smithy/querystring-parser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.0.tgz",
-            "integrity": "sha512-UzHwthk0UEccV4dHzPySnBy34AWw3V9lIqUTxmozQ+wPDAO9csCWMfOLe7V9A2agNYy7xE+Pb0S6K/J23JSzfQ==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+            "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2636,22 +2763,24 @@
             }
         },
         "node_modules/@smithy/service-error-classification": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.0.tgz",
-            "integrity": "sha512-3BsBtOUt2Gsnc3X23ew+r2M71WwtpHfEDGhHYHSDg6q1t8FrWh15jT25DLajFV1H+PpxAJ6gqe9yYeRUsmSdFA==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+            "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0"
+                "@smithy/types": "^3.3.0"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.0.0.tgz",
-            "integrity": "sha512-REVw6XauXk8xE4zo5aGL7Rz4ywA8qNMUn8RtWeTRQsgAlmlvbJ7CEPBcaXU2NDC3AYBgYAXrGyWD8XrN8UGDog==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+            "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2659,14 +2788,16 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.0.0.tgz",
-            "integrity": "sha512-kXFOkNX+BQHe2qnLxpMEaCRGap9J6tUGLzc3A9jdn+nD4JdMwCKTJ+zFwQ20GkY+mAXGatyTw3HcoUlR39HwmA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+            "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/is-array-buffer": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-hex-encoding": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
                 "@smithy/util-uri-escape": "^3.0.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
@@ -2676,15 +2807,16 @@
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.0.1.tgz",
-            "integrity": "sha512-KAiFY4Y4jdHxR+4zerH/VBhaFKM8pbaVmJZ/CWJRwtM/CmwzTfXfvYwf6GoUwiHepdv+lwiOXCuOl6UBDUEINw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+            "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-endpoint": "^3.0.0",
-                "@smithy/middleware-stack": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/util-stream": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.1.0",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-stream": "^3.1.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2692,9 +2824,10 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
-            "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -2703,12 +2836,13 @@
             }
         },
         "node_modules/@smithy/url-parser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.0.tgz",
-            "integrity": "sha512-2XLazFgUu+YOGHtWihB3FSLAfCUajVfNBXGGYjOaVKjLAuAxx3pSBY3hBgLzIgB17haf59gOG3imKqTy8mcrjw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+            "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/querystring-parser": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/querystring-parser": "^3.0.3",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             }
         },
@@ -2760,6 +2894,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
             "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -2768,13 +2903,14 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.1.tgz",
-            "integrity": "sha512-nW5kEzdJn1Bn5TF+gOPHh2rcPli8JU9vSSXLbfg7uPnfR1TMRQqs9zlYRhIb87NeSxIbpdXOI94tvXSy+fvDYg==",
+            "version": "3.0.15",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+            "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^3.0.0",
-                "@smithy/smithy-client": "^3.0.1",
-                "@smithy/types": "^3.0.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             },
@@ -2783,16 +2919,17 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.1.tgz",
-            "integrity": "sha512-TFk+Qb+elLc/MOhtSp+50fstyfZ6avQbgH2d96xUBpeScu+Al9elxv+UFAjaTHe0HQe5n+wem8ZLpXvU8lwV6Q==",
+            "version": "3.0.15",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+            "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/config-resolver": "^3.0.0",
-                "@smithy/credential-provider-imds": "^3.0.0",
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/property-provider": "^3.0.0",
-                "@smithy/smithy-client": "^3.0.1",
-                "@smithy/types": "^3.0.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/credential-provider-imds": "^3.2.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2800,12 +2937,13 @@
             }
         },
         "node_modules/@smithy/util-endpoints": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.0.tgz",
-            "integrity": "sha512-+exaXzEY3DNt2qtA2OtRNSDlVrE4p32j1JSsQkzA5AdP0YtJNjkYbYhJxkFmPYcjI1abuwopOZCwUmv682QkiQ==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
+            "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2816,6 +2954,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
             "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -2824,11 +2963,12 @@
             }
         },
         "node_modules/@smithy/util-middleware": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.0.tgz",
-            "integrity": "sha512-q5ITdOnV2pXHSVDnKWrwgSNTDBAMHLptFE07ua/5Ty5WJ11bvr0vk2a7agu7qRhrCFRQlno5u3CneU5EELK+DQ==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+            "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2836,12 +2976,13 @@
             }
         },
         "node_modules/@smithy/util-retry": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.0.tgz",
-            "integrity": "sha512-nK99bvJiziGv/UOKJlDvFF45F00WgPLKVIGUfAK+mDhzVN2hb/S33uW2Tlhg5PVBoqY7tDVqL0zmu4OxAHgo9g==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+            "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/service-error-classification": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/service-error-classification": "^3.0.3",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2849,13 +2990,14 @@
             }
         },
         "node_modules/@smithy/util-stream": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.1.tgz",
-            "integrity": "sha512-7F7VNNhAsfMRA8I986YdOY5fE0/T1/ZjFF6OLsqkvQVNP3vZ/szYDfGCyphb7ioA09r32K/0qbSFfNFU68aSzA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+            "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/fetch-http-handler": "^3.0.1",
-                "@smithy/node-http-handler": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/fetch-http-handler": "^3.2.4",
+                "@smithy/node-http-handler": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-buffer-from": "^3.0.0",
                 "@smithy/util-hex-encoding": "^3.0.0",
@@ -2981,6 +3123,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
             "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -3001,12 +3144,13 @@
             }
         },
         "node_modules/@smithy/util-waiter": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.0.0.tgz",
-            "integrity": "sha512-+fEXJxGDLCoqRKVSmo0auGxaqbiCo+8oph+4auefYjaNxjOLKSY2MxVQfRzo65PaZv4fr+5lWg+au7vSuJJ/zw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
+            "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/abort-controller": "^3.1.1",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3973,7 +4117,8 @@
         "node_modules/bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "license": "MIT"
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -3986,12 +4131,13 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -5990,19 +6136,20 @@
             "dev": true
         },
         "node_modules/fast-xml-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+            "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
             "funding": [
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/naturalintelligence"
-                },
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/NaturalIntelligence"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "strnum": "^1.0.5"
             },
@@ -6049,10 +6196,11 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -7092,6 +7240,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -8601,12 +8750,13 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -10942,7 +11092,7 @@
         "node_modules/speccy": {
             "version": "0.9.0",
             "resolved": "git+ssh://git@github.com/wework/speccy.git#740d19d88935db7735250c16abc2ad09256b5854",
-            "integrity": "sha512-OyuVMAL72EljLqXWjks7FxSOJGl2Xw+acyO2eHqekGFGS2TFXguO3t0xCn80MQrWLn/FEF66tyNuWpfBSgoFUA==",
+            "integrity": "sha512-TgQCmw07EYo5ZTzTzD0OPnI/6pvsojEk/Ua0u0IiDoXgshhO4U0+GAV5gwGpNoehRgbj0IW8bR1P7q4QoGUFVw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11307,7 +11457,8 @@
         "node_modules/strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "license": "MIT"
         },
         "node_modules/styled-components": {
             "version": "4.4.1",
@@ -11948,6 +12099,7 @@
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -12299,6 +12451,7 @@
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
+            "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
             }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "jest": "^28.1.3",
         "json-schema-ref-parser": "^6.1.0",
         "lint-staged": "^11.0.0",
-        "nodemon": "^2.0.22",
+        "nodemon": "^3.1.4",
         "prettier": "^1.19.1",
         "speccy": "github:wework/speccy#740d19d88935db7735250c16abc2ad09256b5854",
         "yamljs": "^0.3.0"

--- a/trivy.openvex.json
+++ b/trivy.openvex.json
@@ -1,0 +1,17 @@
+{
+    "@context": "https://openvex.dev/ns/v0.2.0",
+    "@id": "https://openvex.dev/docs/public/vex-2e67563e128250cbcb3e98930df948dd053e43271d70dc50cfa22d57e03fe96f",
+    "author": "CICA DEV TEAM",
+    "timestamp": "2024-08-26T13:07:16.853479631-06:00",
+    "version": 1,
+    "statements": [
+        {
+            "vulnerability": {"name": "CVE-2023-45853"},
+            "products": [
+                {"@id": "pkg:deb/debian/zlib1g@1.2.13.dfsg-1?arch=amd64&distro=debian-12.6&epoch=1"}
+            ],
+            "status": "not_affected",
+            "justification": "vulnerable_code_not_in_execute_path"
+        }
+    ]
+}


### PR DESCRIPTION
- Turned on trivy scanning and build failure for CRITICAL vulnerabilities.
- Added VEX file to supress https://github.com/advisories/GHSA-mq29-j5xf-cjwr.
- Bump node container to 20.16.0-bookworm-slim